### PR TITLE
Pass redirect URL and link text as param

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Experimenting with Login.gov authentication by copying two sandbox apps,[identit
 
 You will need to run three servers:
 
-  1. Login's [identity-idp](https://github.com/18F/identity-idp) project at [localhost:3000](http://localhost:3000/). Use these [local development instructions](https://github.com/18F/identity-idp/blob/main/docs/local-development.md).
-    * modify the file config/service_providers.localdev.yml to contain... 
+  1. Login's [identity-idp](https://github.com/18F/identity-idp) project at [localhost:3000](http://localhost:3000/). Here's [how to run it](#setup-of-identity-idp).
   2. The app in this repo's `a-saml` directory at [localhost:4567](http://localhost:4567/)
   3. The app in this repo's `b-oidc` directory at [localhost:9292](http://localhost:9292/)
 
@@ -44,4 +43,17 @@ All three are started with:
   * `make setup` the first time you run each, or after changes
   * `make run`
 
-Visit [Agency A's internal page](http://localhost:4567/internal/) to run the experiment
+  Visit [Agency A's internal page](http://localhost:4567/internal/) to run the experiment
+
+#### Setup of identity-idp
+
+Use these [local development instructions](https://github.com/18F/identity-idp/blob/main/docs/local-development.md).
+
+Modify the file `config/service_providers.localdev.yml` to contain a URI that Login should expect from the a-saml app. Under the section `urn:gov:gsa:openidconnect:sp:sinatra` add these redirect URIs:
+```
+- 'http://localhost:9292/auth/result?redirect=http%3A%2F%2Flocalhost%3A4567%2Finternal%2F&linktext=DogJobs.gov'
+- 'http://localhost:9292/auth/result?redirect=http://localhost:4567/internal/&linktext=DogJobs.gov'
+```
+You will have to run (or re-run) `make setup` after modifying this file
+
+

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ All three are started with:
 
 Use these [local development instructions](https://github.com/18F/identity-idp/blob/main/docs/local-development.md) to setup Login.gov's identity-idp app.
 
-Modify the file `config/service_providers.localdev.yml` to contain a URI that Login should expect from the a-saml app, which makes the "Return to" link in the b-oidc app work. Under the section `urn:gov:gsa:openidconnect:sp:sinatra` add these redirect URIs:
+Modify the file `config/service_providers.localdev.yml` to contain a URI that Login should expect from the a-saml app, which makes the "Return to" link in the b-oidc app work. Add these two lines:
 ```
 - 'http://localhost:9292/auth/result?redirect=http%3A%2F%2Flocalhost%3A4567%2Finternal%2F&linktext=DogJobs.gov'
 - 'http://localhost:9292/auth/result?redirect=http://localhost:4567/internal/&linktext=DogJobs.gov'
 ```
+In the part of the file configuring `urn:gov:gsa:openidconnect:sp:sinatra`
+
 You will have to run (or re-run) `make setup` after modifying this file.
 
 The purpose of this is to allow-list params the Sinatra pair experiment needs. This error indicates either the allow-listing or the params are incorrect:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Experimenting with Login.gov authentication by copying two sandbox apps,[identit
 You will need to run three servers:
 
   1. Login's [identity-idp](https://github.com/18F/identity-idp) project at [localhost:3000](http://localhost:3000/). Use these [local development instructions](https://github.com/18F/identity-idp/blob/main/docs/local-development.md).
+    * modify the file config/service_providers.localdev.yml to contain... 
   2. The app in this repo's `a-saml` directory at [localhost:4567](http://localhost:4567/)
   3. The app in this repo's `b-oidc` directory at [localhost:9292](http://localhost:9292/)
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # 10x-data-exchange
 
-## About this project
-
-### Original project description
-
-We have observed that the public does not have a good understanding of what happens to their data when they share it with the federal government, which results in low public trust, low sign up for optional services intended to benefit the public, and underreporting of civil rights and whistleblower complaints. We believe that by creating a "data passport" or personal file that would allow people to see who accessed the data that they shared with the government and when, or opt into sharing information to match for service eligibility or allow the government to prefill forms like taxes or enrollment forms, that it would result in a more transparent relationship between the public and government and increase public trust. In addition, 10x will explore the concept of a public data trust, which means involving the public not just in information sharing, but in the process of analyzing and making decisions based off that data as well.
-
-### Links to understand the context
+Experiments in consumer-mediated exchange of data between agency partners
 
 * [Data Exchange README](https://docs.google.com/document/d/1IfLms6VMIaOpkgdy0_DiDTQXpntpgtQZgoTyKUExCTw/)
 * [Project folder on Google Drive](https://drive.google.com/drive/folders/1Xv6QOYEFwhMv2SfVHi9Rzl4XASAvnbXc)
@@ -47,13 +41,16 @@ All three are started with:
 
 #### Setup of identity-idp
 
-Use these [local development instructions](https://github.com/18F/identity-idp/blob/main/docs/local-development.md).
+Use these [local development instructions](https://github.com/18F/identity-idp/blob/main/docs/local-development.md) to setup Login.gov's identity-idp app.
 
-Modify the file `config/service_providers.localdev.yml` to contain a URI that Login should expect from the a-saml app. Under the section `urn:gov:gsa:openidconnect:sp:sinatra` add these redirect URIs:
+Modify the file `config/service_providers.localdev.yml` to contain a URI that Login should expect from the a-saml app, which makes the "Return to" link in the b-oidc appwork. Under the section `urn:gov:gsa:openidconnect:sp:sinatra` add these redirect URIs:
 ```
 - 'http://localhost:9292/auth/result?redirect=http%3A%2F%2Flocalhost%3A4567%2Finternal%2F&linktext=DogJobs.gov'
 - 'http://localhost:9292/auth/result?redirect=http://localhost:4567/internal/&linktext=DogJobs.gov'
 ```
-You will have to run (or re-run) `make setup` after modifying this file
+You will have to run (or re-run) `make setup` after modifying this file.
 
-
+The purpose of this is to allow-list params the Sinatra pair experiment needs. This error indicates either the allow-listing or the params are incorrect:
+```
+Redirect uri redirect_uri does not match registered redirect_uri
+```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All three are started with:
 
 Use these [local development instructions](https://github.com/18F/identity-idp/blob/main/docs/local-development.md) to setup Login.gov's identity-idp app.
 
-Modify the file `config/service_providers.localdev.yml` to contain a URI that Login should expect from the a-saml app, which makes the "Return to" link in the b-oidc appwork. Under the section `urn:gov:gsa:openidconnect:sp:sinatra` add these redirect URIs:
+Modify the file `config/service_providers.localdev.yml` to contain a URI that Login should expect from the a-saml app, which makes the "Return to" link in the b-oidc app work. Under the section `urn:gov:gsa:openidconnect:sp:sinatra` add these redirect URIs:
 ```
 - 'http://localhost:9292/auth/result?redirect=http%3A%2F%2Flocalhost%3A4567%2Finternal%2F&linktext=DogJobs.gov'
 - 'http://localhost:9292/auth/result?redirect=http://localhost:4567/internal/&linktext=DogJobs.gov'

--- a/sinatra-pair/b-oidc/app.rb
+++ b/sinatra-pair/b-oidc/app.rb
@@ -116,7 +116,7 @@ module LoginGov::OidcSinatra
           session[:userinfo] = userinfo_response
           session[:email] = session[:userinfo][:email]
 
-          redirect to('/internal/?redirect=http://localhost:4567/internal')
+          redirect to('/internal/?redirect='+params[:redirect].to_s+'&linktext='+params[:linktext].to_s)
         end
       else
         error = params[:error] || 'missing callback param: code'
@@ -168,7 +168,7 @@ module LoginGov::OidcSinatra
         response_type: 'code',
         acr_values: acr_values(ial: ial, aal: aal),
         scope: scopes_for(ial),
-        redirect_uri: File.join(config.redirect_uri, '/auth/result'),
+        redirect_uri: File.join(config.redirect_uri, "/auth/result?redirect=#{params[:redirect]}&linktext=#{params[:linktext]}"),
         state: random_value,
         nonce: random_value,
         prompt: 'select_account',

--- a/sinatra-pair/b-oidc/views/internal.erb
+++ b/sinatra-pair/b-oidc/views/internal.erb
@@ -24,6 +24,7 @@
             <li><a href="/assets/img/k9.pdf" download>Download form K-9</a></li>
             <li><a href="#" id="redirect">where you came from</a></li>
         </ol>
+        <p>Or, <a href="<%= logout_uri %>">log out</a>.</p>
 
         <script>
             let urlParams = new URLSearchParams(window.location.search);
@@ -39,7 +40,9 @@
     <% else %>
         <p>You must sign in</p>
 
-        <form action="/auth/request">
+        <form action="/auth/request" action="get">
+            <input name="redirect" id="redirect" type="hidden" value="<%= params[:redirect] %>" />
+            <input name="linktext" id="linktext" type="hidden" value="<%= params[:linktext] %>" />
             <button type="submit" class="usa-button usa-button--outline sign-in-bttn">
                 <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                     <path fill="currentColor" d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path>
@@ -48,4 +51,5 @@
             </button>
         </form>
     <% end %>
+
 </main>

--- a/sinatra-pair/b-oidc/views/internal.erb
+++ b/sinatra-pair/b-oidc/views/internal.erb
@@ -51,5 +51,4 @@
             </button>
         </form>
     <% end %>
-
 </main>


### PR DESCRIPTION
Pass text and URL of "Return to..." button from Agency A, though Login.gov, and to Agency B as a URL param. Include instructions for allow-listing this data at Login.gov.